### PR TITLE
Features/result

### DIFF
--- a/docs/source/user/errors.rst
+++ b/docs/source/user/errors.rst
@@ -4,9 +4,50 @@ Dealing with errors
 .. note::
 
    This chapter describe common error that may happen at runtime.
-   Some exception can happen during the registration phase, using 
+   Some exception can happen during the registration phase, using
    the function :func:`blacksmith.scan` which are not par not
    runtime desigated runtime errors here.
+
+HTTP Errors
+-----------
+
+.. versionchanged:: 2.0
+
+   the HTTP Errors are not throws anymore.
+
+When a resource is consuming a get, post, put, patch, delete, collection_get,
+and so on, the function return a Result object that have method to unwrap
+the resource or the associated error.
+
+An error is a class :class:`blacksmith.HTTPError` and get the ``status_code``
+of the errors with a JSON payload.
+
+
+Async example
+~~~~~~~~~~~~~
+
+.. literalinclude:: errors_01.py
+
+Sync example
+~~~~~~~~~~~~
+
+.. literalinclude:: errors_02.py
+
+
+
+.. note::
+
+   Blacksmith does not declare schema for errors.
+   It could be an improvement in the future.
+
+   Usually, a set of API share the same format for all the errors,
+   but sometime, errors may also be html, so it is not possible to
+   have a schema for errors.
+
+The error is supposed to be a json document, under attribute ``json``.
+If it is not the case, the content of the document will be in plain text
+under the key ``detail``.
+
 
 Timeout
 -------
@@ -18,26 +59,6 @@ factory, and can be overriden on every http call.
 The default connect timeout is at 15 seconds.
 
 .. literalinclude:: errors_timeout.py
-
-HTTP Errors
------------
-
-Blacksmith does not declare schema for errors.
-
-It raised exceptions instead.
-
-The exception raised is :class:`blacksmith.HTTPError` and get the
-``status_code`` of the error.
-
-.. note::
-
-   Usually, a set of API share the same format for all the errors,
-   but sometime, errors may also be html, so it is not possible to
-   have a schema for errors.
-
-The error is supposed to be a json document, under attribute ``json``.
-If it is not the case, the content of the document will be in plain text
-under the key ``detail``.
 
 
 Opened Circuit Breaker

--- a/docs/source/user/errors_01.py
+++ b/docs/source/user/errors_01.py
@@ -1,0 +1,27 @@
+from result import Result
+
+from blacksmith import (
+    AsyncClientFactory,
+    AsyncStaticDiscovery,
+    CollectionIterator,
+    ResponseBox,
+)
+
+from .resources import Item, PartialItem
+
+
+async def main():
+    sd = AsyncStaticDiscovery({("api", None): "http://srv:8000/"})
+    cli = AsyncClientFactory(sd)
+    api = await cli("api")
+    items: Result[CollectionIterator[PartialItem]] = await api.item.collection_get()
+    if items.is_ok():
+        for item in items.unwrap():
+            rfull_item: ResponseBox[Item] = await api.item.get({"name": item.name})
+            if rfull_item.is_err():
+                print(f"Unexpected error: {rfull_item.json}")
+                continue
+            full_item = rfull_item.unwrap()
+            print(full_item)
+    err = items.unwrap_err()
+    print(f"Unexpected error: {err.json}")

--- a/docs/source/user/errors_02.py
+++ b/docs/source/user/errors_02.py
@@ -1,0 +1,27 @@
+from result import Result
+
+from blacksmith import (
+    CollectionIterator,
+    ResponseBox,
+    SyncClientFactory,
+    SyncStaticDiscovery,
+)
+
+from .resources import Item, PartialItem
+
+
+def main():
+    sd = SyncStaticDiscovery({("api", None): "http://srv:8000/"})
+    cli = SyncClientFactory(sd)
+    api = cli("api")
+    items: Result[CollectionIterator[PartialItem]] = api.item.collection_get()
+    if items.is_ok():
+        for item in items.unwrap():
+            rfull_item: ResponseBox[Item] = api.item.get({"name": item.name})
+            if rfull_item.is_err():
+                print(f"Unexpected error: {rfull_item.json}")
+                continue
+            full_item = rfull_item.unwrap()
+            print(full_item)
+    err = items.unwrap_err()
+    print(f"Unexpected error: {err.json}")

--- a/docs/source/user/errors_timeout.py
+++ b/docs/source/user/errors_timeout.py
@@ -18,12 +18,10 @@ async def main():
     api = await cli("api")
 
     # user the default timeout
-    resources = await api.resource.collection_get()  # noqa
+    resp = await api.resource.collection_get()  # noqa
 
     # force the timeout
-    resources = await api.resource.collection_get(timeout=42.0)  # noqa
+    resp = await api.resource.collection_get(timeout=42.0)  # noqa
 
     # Or even with a connect timeout using the HTTPTimeout class
-    resources = await api.resource.collection_get(  # noqa
-        timeout=HTTPTimeout(42.0, 7.0)
-    )
+    resp = await api.resource.collection_get(timeout=HTTPTimeout(42.0, 7.0))  # noqa

--- a/docs/source/user/glossary.rst
+++ b/docs/source/user/glossary.rst
@@ -50,6 +50,10 @@ Glossary
       | Type hints provides user friendly errors when data is invalid.
       | Website: https://pydantic-docs.helpmanual.io/
 
+   result library
+      | A simple Result type for Python 3 inspired by Rust, fully type annotated.
+      | Website: https://pypi.org/project/result/
+
    server-side service discovery
       The client is calling a proxy server that maintain its backends server
       list by receiving notification of the :term:`service registry` to maintain.

--- a/docs/source/user/instanciating_client_01.py
+++ b/docs/source/user/instanciating_client_01.py
@@ -5,5 +5,9 @@ async def main():
     sd = AsyncStaticDiscovery({("api", None): "http://srv:8000/"})
     cli = AsyncClientFactory(sd)
     api = await cli("api")
-    items = await api.item.collection_get()
-    print(items)
+    result = await api.item.collection_get()
+    if result.is_ok():
+        for item in result.unwrap():
+            print(item)
+    else:
+        print(result.unwrap_err())

--- a/docs/source/user/instanciating_client_02.py
+++ b/docs/source/user/instanciating_client_02.py
@@ -1,3 +1,5 @@
+from result import Result
+
 from blacksmith import AsyncClientFactory, AsyncStaticDiscovery, CollectionIterator
 
 from .resources import Item, PartialItem
@@ -7,7 +9,7 @@ async def main():
     sd = AsyncStaticDiscovery({("api", None): "http://srv:8000/"})
     cli = AsyncClientFactory(sd)
     api = await cli("api")
-    items: CollectionIterator[PartialItem] = await api.item.collection_get()
-    for item in items:
-        full_item: Item = (await api.item.get({"name": item.name})).response
+    items: Result[CollectionIterator[PartialItem]] = await api.item.collection_get()
+    for item in items.unwrap():
+        full_item: Item = (await api.item.get({"name": item.name})).unwrap()
         print(full_item)

--- a/docs/source/user/instanciating_client_03.py
+++ b/docs/source/user/instanciating_client_03.py
@@ -1,3 +1,5 @@
+from result import Result
+
 from blacksmith import CollectionIterator, SyncClientFactory, SyncStaticDiscovery
 
 from .resources import Item, PartialItem
@@ -7,7 +9,7 @@ def main():
     sd = SyncStaticDiscovery({("api", None): "http://srv:8000/"})
     cli = SyncClientFactory(sd)
     api = cli("api")
-    items: CollectionIterator[PartialItem] = api.item.collection_get()
-    for item in items:
-        full_item: Item = (api.item.get({"name": item.name})).response
+    items: Result[CollectionIterator[PartialItem]] = api.item.collection_get()
+    for item in items.unwrap():
+        full_item: Item = (api.item.get({"name": item.name})).unwrap()
         print(full_item)

--- a/docs/source/user/instanciating_clients.rst
+++ b/docs/source/user/instanciating_clients.rst
@@ -50,6 +50,15 @@ example bellow:
    The method accept a dict version of the request schema.
 
 
+.. versionchanged:: 2.0
+
+   Since blacksmith 2.0, responses are wrapped using the :term:`result library`.
+
+   The collection class return a ``result.Result`` object, and the non collection,
+   return a :class:`blacksmith.ResponseBox` that have the same mimic of the
+   ``result.Result``. of the :term:`result library`.
+
+
 Synchronous API
 ---------------
 

--- a/examples/circuit_breaker/notif/src/notif/views.py
+++ b/examples/circuit_breaker/notif/src/notif/views.py
@@ -63,7 +63,7 @@ async def get_notif(request):
 async def post_notif(request):
     body = await request.json()
     api_user = await cli("api_user")
-    user: User = (await api_user.users.get({"username": body["username"]})).response
+    user: User = (await api_user.users.get({"username": body["username"]})).unwrap()
     await send_email(user, body["message"])
     return JSONResponse({"detail": f"{user.email} accepted"}, status_code=202)
 

--- a/examples/consul_sd/notif/src/notif/views.py
+++ b/examples/consul_sd/notif/src/notif/views.py
@@ -46,6 +46,6 @@ async def get_notif(request):
 async def post_notif(request):
     body = await request.json()
     api_user = await cli("api_user")
-    user: User = (await api_user.users.get({"username": body["username"]})).response
+    user: User = (await api_user.users.get({"username": body["username"]})).unwrap()
     await send_email(user, body["message"])
     return JSONResponse({"detail": f"{user.email} accepted"}, status_code=202)

--- a/examples/consul_template_sd/notif/src/notif/views.py
+++ b/examples/consul_template_sd/notif/src/notif/views.py
@@ -46,6 +46,6 @@ async def get_notif(request):
 async def post_notif(request):
     body = await request.json()
     api_user = await cli("api_user")
-    user: User = (await api_user.users.get({"username": body["username"]})).response
+    user: User = (await api_user.users.get({"username": body["username"]})).unwrap()
     await send_email(user, body["message"])
     return JSONResponse({"detail": f"{user.email} accepted"}, status_code=202)

--- a/examples/gandi_domain.py
+++ b/examples/gandi_domain.py
@@ -35,12 +35,15 @@ class PartialDomain(Response):
     owner: str
     dates: Dates
 
+
 class Contact(BaseModel):
     firstname: str = Field(alias="given")
     lastname: str = Field(alias="family")
 
+
 class Contacts(BaseModel):
     owner: Contact = Field(...)
+
 
 class Domain(Response):
     name: str = Field(alias="fqdn_unicode")
@@ -97,5 +100,6 @@ async def main():
         print()
         for domain in domains:
             print(domain)
+
 
 asyncio.run(main())

--- a/examples/gandi_domain.py
+++ b/examples/gandi_domain.py
@@ -27,17 +27,29 @@ class Dates(BaseModel):
     # updated_at: datetime.datetime
 
 
-class ListDomainResponse(Response):
+class PartialDomain(Response):
     # id: uuid.UUID
     # fqdn: str
     # In this example we rename a field in the response using `alias`
-    name: str = Field(str, alias="fqdn_unicode")
+    name: str = Field(..., alias="fqdn_unicode")
     owner: str
+    dates: Dates
+
+class Contact(BaseModel):
+    firstname: str = Field(alias="given")
+    lastname: str = Field(alias="family")
+
+class Contacts(BaseModel):
+    owner: Contact = Field(...)
+
+class Domain(Response):
+    name: str = Field(alias="fqdn_unicode")
+    contacts: Contacts
     dates: Dates
 
 
 class DomainParam(Request):
-    name: str = PathInfoField(str)
+    name: str = PathInfoField(...)
 
 
 class CollectionDomainParam(Request):
@@ -53,11 +65,11 @@ register(
     contract={
         # In this example we don't provide the response model,
         # so we receive a dict for the json response
-        "GET": (DomainParam, None),
+        "GET": (DomainParam, Domain),
     },
     collection_path="/domain/domains",
     collection_contract={
-        "GET": (CollectionDomainParam, ListDomainResponse),
+        "GET": (CollectionDomainParam, PartialDomain),
     },
 )
 
@@ -69,22 +81,21 @@ async def main():
     apikey = os.environ["GANDIV5_API_KEY"]
     sd = AsyncStaticDiscovery({("gandi", "v5"): "https://api.gandi.net/v5"})
     auth = AsyncHTTPAuthorizationMiddleware("Apikey", apikey)
-    cli: AsyncClientFactory[ListDomainResponse, Any] = AsyncClientFactory(
+    cli: AsyncClientFactory[PartialDomain, Any] = AsyncClientFactory(
         sd, timeout=(10.0)
     ).add_middleware(auth)
     api = await cli("gandi")
     if len(sys.argv) == 2:
         domain = sys.argv[1]
-        domain = await api.domain.get(DomainParam(name=domain))
-        print(domain.json)
+        domain_result = await api.domain.get(DomainParam(name=domain))
+        domain = domain_result.unwrap()
+        print(domain)
     else:
-        domains = await api.domain.collection_get()
-
+        domain_result = await api.domain.collection_get()
+        domains = domain_result.unwrap()
         print(domains.meta)
         print()
         for domain in domains:
             print(domain)
-            print(domain.name)
-
 
 asyncio.run(main())

--- a/examples/gandi_tld.py
+++ b/examples/gandi_tld.py
@@ -54,7 +54,7 @@ async def main():
         auth
     )
     api = await cli("gandi")
-    tld = (await api.tld.get(TLDInfoGetParam(name="eu"))).response
+    tld = (await api.tld.get(TLDInfoGetParam(name="eu"))).unwrap()
     print(tld)
 
 

--- a/examples/http_cache/notif/src/notif/views.py
+++ b/examples/http_cache/notif/src/notif/views.py
@@ -57,7 +57,7 @@ async def get_notif(request):
 async def post_notif(request):
     body = await request.json()
     api_user = await cli("api_user")
-    user: User = (await api_user.users.get({"username": body["username"]})).response
+    user: User = (await api_user.users.get({"username": body["username"]})).unwrap()
     await send_email(user, body["message"])
     return JSONResponse({"detail": f"{user.email} accepted"}, status_code=202)
 

--- a/examples/prometheus_metrics/notif/src/notif/views.py
+++ b/examples/prometheus_metrics/notif/src/notif/views.py
@@ -48,7 +48,7 @@ async def get_notif(request):
 async def post_notif(request):
     body = await request.json()
     api_user = await cli("api_user")
-    user: User = (await api_user.users.get({"username": body["username"]})).response
+    user: User = (await api_user.users.get({"username": body["username"]})).unwrap()
     await send_email(user, body["message"])
     return JSONResponse({"detail": f"{user.email} accepted"}, status_code=202)
 

--- a/examples/unittesting/notif/src/notif/views.py
+++ b/examples/unittesting/notif/src/notif/views.py
@@ -13,6 +13,6 @@ async def post_notif(
 ):
     body = await request.json()
     api_user = await app.get_client("api_user")
-    user: User = (await api_user.users.get({"username": body["username"]})).response
+    user: User = (await api_user.users.get({"username": body["username"]})).unwrap()
     await app.send_email(user, body["message"])
     return JSONResponse({"detail": f"{user.email} accepted"}, status_code=202)

--- a/examples/zipkin_tracing/notif/src/notif/views.py
+++ b/examples/zipkin_tracing/notif/src/notif/views.py
@@ -57,7 +57,7 @@ async def post_notif(request):
 
     api_user = await cli("api_user")
     try:
-        user: User = (await api_user.users.get({"username": body["username"]})).response
+        user: User = (await api_user.users.get({"username": body["username"]})).unwarp()
     except HTTPError as exc:
         status_code = exc.response.status_code
         resp = exc.response.json

--- a/poetry.lock
+++ b/poetry.lock
@@ -710,6 +710,17 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "result"
+version = "0.8.0"
+description = "A Rust-like result type for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
+
+[[package]]
 name = "rfc3986"
 version = "1.5.0"
 description = "Validating URI References per RFC 3986"
@@ -1035,7 +1046,7 @@ prometheus = ["prometheus-client"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "79ad0f5369af938d140d4498bd26d78733479b4dffaa984e4040220aa37e488a"
+content-hash = "7669feacd10ffffeb8c2c13a701dfb4bba4e5157193b3acbb87155ad6a4df2cf"
 
 [metadata.files]
 aiohttp = [
@@ -1624,6 +1635,10 @@ redis = [
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+result = [
+    {file = "result-0.8.0-py3-none-any.whl", hash = "sha256:d6a6258f32c057a4e0478999c6ce43dcadaf8ea435f58ac601ae2768f93ef243"},
+    {file = "result-0.8.0.tar.gz", hash = "sha256:c48c909e92181a075ba358228a3fe161e26d205dad416ad81f27f23515a5626d"},
 ]
 rfc3986 = [
     {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ purgatory = "^1.0.1"
 pydantic = "^1.8.2"
 python = "^3.7"
 typing-extensions = "^4.0.1"
+result = "^0.8.0"
 
 [tool.poetry.extras]
 http_cache_async = ["aioredis"]

--- a/src/blacksmith/domain/exceptions.py
+++ b/src/blacksmith/domain/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import TYPE_CHECKING, Any, Type
 
 from blacksmith.typing import (
     ClientName,
@@ -10,6 +10,9 @@ from blacksmith.typing import (
     ServiceName,
     Version,
 )
+
+if TYPE_CHECKING:
+    from .model.http import HTTPRequest, HTTPResponse
 
 
 class ConfigurationError(Exception):
@@ -97,9 +100,7 @@ class WrongRequestTypeException(TypeError):
 class HTTPError(Exception):
     """Represent the http error."""
 
-    from .model.http import HTTPRequest, HTTPResponse
-
-    def __init__(self, message: str, request: HTTPRequest, response: HTTPResponse):
+    def __init__(self, message: str, request: "HTTPRequest", response: "HTTPResponse"):
         super().__init__(message)
         self.request = request
         self.response = response

--- a/src/blacksmith/domain/model/params.py
+++ b/src/blacksmith/domain/model/params.py
@@ -243,7 +243,7 @@ class ResponseBox(Generic[TResponse]):
         .. deprecated:: 2.0
             Use :meth:`ResponseBox.unwrap()`
 
-        :raises HTTPError: if the response conains an error.
+        :raises blacksmith.HTTPError: if the response conains an error.
         :raises NoResponseSchemaException: if the response_schema has not been
             set in the contract.
         """

--- a/src/blacksmith/domain/model/params.py
+++ b/src/blacksmith/domain/model/params.py
@@ -281,6 +281,14 @@ class ResponseBox(Generic[TResponse]):
         resp = self.raw_result.map(self._cast_resp)
         return cast(Result[TResponse, HTTPError], resp).unwrap_or_else(op)
 
+    def expect(self, message: str) -> TResponse:
+        """Return the response raise an UnwrapError exception with the given message."""
+        return self.raw_result.map(self._cast_resp).expect(message)
+
+    def expect_err(self, message: str) -> HTTPError:
+        """Return the error or raise an UnwrapError exception with the given message."""
+        return self.raw_result.expect_err(message)
+
 
 class CollectionIterator(Iterator[TResponse]):
     """

--- a/src/blacksmith/domain/model/params.py
+++ b/src/blacksmith/domain/model/params.py
@@ -320,7 +320,25 @@ class ResponseBox(Generic[TResponse]):
         """
         Apply op on error in case of error, and return the new result.
         """
+        # works in mypy, not in pylance
         return self.raw_result.map(self._cast_resp).map_err(op)  # type: ignore
+
+    def and_then(
+        self, op: Callable[[TResponse], Result[U, HTTPError]]
+    ) -> Result[U, HTTPError]:
+        """
+        Apply the op function on the response and return it if success
+        """
+        # works in mypy, not in pylance
+        return self.raw_result.map(self._cast_resp).and_then(op)  # type: ignore
+
+    def or_else(
+        self, op: Callable[[HTTPError], Result[TResponse, F]]
+    ) -> Result[TResponse, F]:
+        """
+        Apply the op function on the error and return it if error
+        """
+        return self.raw_result.map(self._cast_resp).or_else(op)  # type: ignore
 
 
 class CollectionIterator(Iterator[TResponse]):

--- a/src/blacksmith/domain/model/params.py
+++ b/src/blacksmith/domain/model/params.py
@@ -276,8 +276,13 @@ class ResponseBox(Generic[TResponse]):
         """Return the response error."""
         return self.raw_result.unwrap_err()
 
+    def unwrap_or(self, default: TResponse) -> TResponse:
+        """Return the response or the default value in case of error."""
+        resp = self.raw_result.map(self._cast_resp)
+        return cast(Result[TResponse, HTTPError], resp).unwrap_or(default)
+
     def unwrap_or_else(self, op: Callable[[HTTPError], TResponse]) -> TResponse:
-        """Return the response or the op return in case of error."""
+        """Return the response or the callable return in case of error."""
         resp = self.raw_result.map(self._cast_resp)
         return cast(Result[TResponse, HTTPError], resp).unwrap_or_else(op)
 

--- a/src/blacksmith/domain/model/params.py
+++ b/src/blacksmith/domain/model/params.py
@@ -350,15 +350,13 @@ class CollectionIterator(Iterator[TResponse]):
 
     def __init__(
         self,
-        response: Result[HTTPResponse, HTTPError],
+        response: HTTPResponse,
         response_schema: Optional[Type[Response]],
         collection_parser: Type[AbstractCollectionParser],
     ) -> None:
         self.pos = 0
         self.response_schema = response_schema
-        if response.is_err():
-            raise response.unwrap_err()
-        self.response = collection_parser(response.unwrap())
+        self.response = collection_parser(response)
         self.json_resp = self.response.json
 
     @property

--- a/src/blacksmith/sd/_async/adapters/consul.py
+++ b/src/blacksmith/sd/_async/adapters/consul.py
@@ -7,6 +7,7 @@ import random
 from typing import Any, Callable, List
 
 from pydantic.fields import Field
+from result import Result
 
 from blacksmith.domain.exceptions import HTTPError, UnregisteredServiceException
 from blacksmith.domain.model import PathInfoField, Request, Response
@@ -125,14 +126,15 @@ class AsyncConsulDiscovery(AsyncAbstractServiceDiscovery):
         """
         name = self.format_service_name(service, version)
         consul = await self.blacksmith_cli("consul")
-        try:
-            iresp: CollectionIterator[Service] = await consul.services.collection_get(
-                ServiceRequest(name=name)
-            )
-        except HTTPError as exc:
-            raise ConsulApiError(exc)  # rewrite the class to avoid confusion
+        rresp: Result[
+            CollectionIterator[Service], HTTPError
+        ] = await consul.services.collection_get(ServiceRequest(name=name))
+        if rresp.is_err():
+            raise ConsulApiError(
+                rresp.unwrap_err()
+            )  # rewrite the class to avoid confusion
         else:
-            resp: List[Service] = list(iresp)
+            resp: List[Service] = list(rresp.unwrap())
             if not resp:
                 raise UnregisteredServiceException(service, version)
             return random.choice(resp)

--- a/src/blacksmith/service/_async/route_proxy.py
+++ b/src/blacksmith/service/_async/route_proxy.py
@@ -128,7 +128,9 @@ class AsyncRouteProxy(Generic[TCollectionResponse, TResponse]):
         else:
             return Ok(
                 CollectionIterator(
-                    result, response_schema, collection_parser or self.collection_parser
+                    result.unwrap(),
+                    response_schema,
+                    collection_parser or self.collection_parser,
                 )
             )
 

--- a/src/blacksmith/service/_sync/route_proxy.py
+++ b/src/blacksmith/service/_sync/route_proxy.py
@@ -128,7 +128,9 @@ class SyncRouteProxy(Generic[TCollectionResponse, TResponse]):
         else:
             return Ok(
                 CollectionIterator(
-                    result, response_schema, collection_parser or self.collection_parser
+                    result.unwrap(),
+                    response_schema,
+                    collection_parser or self.collection_parser,
                 )
             )
 

--- a/src/blacksmith/service/_sync/route_proxy.py
+++ b/src/blacksmith/service/_sync/route_proxy.py
@@ -121,11 +121,16 @@ class SyncRouteProxy(Generic[TCollectionResponse, TResponse]):
         result: Result[HTTPResponse, HTTPError],
         response_schema: Optional[Type[Response]],
         collection_parser: Optional[Type[AbstractCollectionParser]],
-    ) -> CollectionIterator[TCollectionResponse]:
+    ) -> Result[CollectionIterator[TCollectionResponse], HTTPError]:
 
-        return CollectionIterator(
-            result, response_schema, collection_parser or self.collection_parser
-        )
+        if result.is_err():
+            return Err(result.unwrap_err())
+        else:
+            return Ok(
+                CollectionIterator(
+                    result, response_schema, collection_parser or self.collection_parser
+                )
+            )
 
     def _handle_req_with_middlewares(
         self, req: HTTPRequest, timeout: HTTPTimeout, path: Path
@@ -146,7 +151,7 @@ class SyncRouteProxy(Generic[TCollectionResponse, TResponse]):
         params: Union[Optional[Request], Dict[Any, Any]],
         timeout: HTTPTimeout,
         collection: HttpCollection,
-    ) -> CollectionIterator[TCollectionResponse]:
+    ) -> Result[CollectionIterator[TCollectionResponse], HTTPError]:
         path, req, resp_schema = self._prepare_request(method, params, collection)
         resp = self._handle_req_with_middlewares(req, timeout, path)
         return self._prepare_collection_response(
@@ -190,7 +195,7 @@ class SyncRouteProxy(Generic[TCollectionResponse, TResponse]):
         self,
         params: Union[Optional[Request], Dict[Any, Any]] = None,
         timeout: Optional[ClientTimeout] = None,
-    ) -> CollectionIterator[TCollectionResponse]:
+    ) -> Result[CollectionIterator[TCollectionResponse], HTTPError]:
         if not self.routes.collection:
             raise UnregisteredRouteException("GET", self.name, self.client_name)
         return self._yield_collection_request(

--- a/src/blacksmith/service/_sync/route_proxy.py
+++ b/src/blacksmith/service/_sync/route_proxy.py
@@ -1,6 +1,9 @@
 from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union
 
+from result import Err, Ok, Result
+
 from blacksmith.domain.exceptions import (
+    HTTPError,
     NoContractException,
     UnregisteredRouteException,
     WrongRequestTypeException,
@@ -99,13 +102,13 @@ class SyncRouteProxy(Generic[TCollectionResponse, TResponse]):
 
     def _prepare_response(
         self,
-        response: HTTPResponse,
+        result: Result[HTTPResponse, HTTPError],
         response_schema: Optional[Type[Response]],
         method: HTTPMethod,
         path: Path,
     ) -> ResponseBox[TResponse]:
         return ResponseBox[TResponse](
-            response,
+            result,
             response_schema,
             method,
             path,
@@ -115,24 +118,27 @@ class SyncRouteProxy(Generic[TCollectionResponse, TResponse]):
 
     def _prepare_collection_response(
         self,
-        response: HTTPResponse,
+        result: Result[HTTPResponse, HTTPError],
         response_schema: Optional[Type[Response]],
         collection_parser: Optional[Type[AbstractCollectionParser]],
     ) -> CollectionIterator[TCollectionResponse]:
 
         return CollectionIterator(
-            response, response_schema, collection_parser or self.collection_parser
+            result, response_schema, collection_parser or self.collection_parser
         )
 
     def _handle_req_with_middlewares(
         self, req: HTTPRequest, timeout: HTTPTimeout, path: Path
-    ) -> HTTPResponse:
+    ) -> Result[HTTPResponse, HTTPError]:
         next: SyncMiddleware = self.transport
         for middleware in self.middlewares:
             next = middleware(next)
 
-        resp = next(req, self.client_name, path, timeout)
-        return resp
+        try:
+            resp = next(req, self.client_name, path, timeout)
+        except HTTPError as exc:
+            return Err(exc)
+        return Ok(resp)
 
     def _yield_collection_request(
         self,

--- a/tests/functionals/test_api_client.py
+++ b/tests/functionals/test_api_client.py
@@ -119,6 +119,7 @@ async def test_crud(dummy_api_endpoint: str):
 
     # Test with the dict syntax
     items = await api.item.collection_get({"name": "z"})
+    assert items.is_ok()
     litems = list(items.unwrap())
     assert litems == [
         Item(name="zdummy", size=SizeEnum.l),

--- a/tests/functionals/test_api_client.py
+++ b/tests/functionals/test_api_client.py
@@ -17,6 +17,7 @@ from blacksmith import (
     register,
 )
 from blacksmith.domain.exceptions import NoContractException
+from blacksmith.domain.model.params import ResponseBox
 
 
 class SizeEnum(str, Enum):
@@ -76,19 +77,22 @@ async def test_crud(dummy_api_endpoint: str):
     api = await cli("api")
 
     items: Result[CollectionIterator[Any], HTTPError] = await api.item.collection_get()
+    assert items.is_ok()
     llitems = list(items.unwrap())
     assert llitems == []
 
-    await api.item.collection_post(CreateItem(name="dummy0", size=SizeEnum.s))
+    resp = await api.item.collection_post(CreateItem(name="dummy0", size=SizeEnum.s))
+    assert resp.is_ok()
 
     items = await api.item.collection_get(ListItem())
     litems = list(items.unwrap())
     assert litems == [Item(name="dummy0", size=SizeEnum.s)]
 
-    await api.item.collection_post({"name": "dummy1", "size": SizeEnum.m})
+    resp = await api.item.collection_post({"name": "dummy1", "size": SizeEnum.m})
+    assert resp.is_ok()
 
     items = await api.item.collection_get(ListItem())
-    assert items.is_ok
+    assert items.is_ok()
     litems = list(items.unwrap())
     assert litems == [
         Item(name="dummy0", size=SizeEnum.s),
@@ -96,11 +100,14 @@ async def test_crud(dummy_api_endpoint: str):
     ]
 
     # Test http error
-    with pytest.raises(HTTPError) as exc:
-        await api.item.collection_post(CreateItem(name="dummy0", size=SizeEnum.s))
-    assert exc.value.status_code == 409
-    assert exc.value.json == {"detail": "Already Exists"}
-    assert str(exc.value) == "api - POST /items - 409 Conflict"
+    op_result = await api.item.collection_post(
+        CreateItem(name="dummy0", size=SizeEnum.s)
+    )
+    assert op_result.is_err()
+    exc = op_result.unwrap_err()
+    assert exc.status_code == 409
+    assert exc.json == {"detail": "Already Exists"}
+    assert str(exc) == "api - POST /items - 409 Conflict"
 
     # Test the filter parameter in query string
     await api.item.collection_post({"name": "zdummy", "size": "L"})
@@ -118,20 +125,25 @@ async def test_crud(dummy_api_endpoint: str):
     ]
 
     # Test get
-    item: Item = (await api.item.get(GetItem(item_name="zdummy"))).response
-    assert item == Item(name="zdummy", size=SizeEnum.l)
+    item: ResponseBox[Item] = await api.item.get(GetItem(item_name="zdummy"))
+    assert item.is_ok()
+    assert item.unwrap() == Item(name="zdummy", size=SizeEnum.l)
 
-    item = (await api.item.get({"item_name": "zdummy"})).response
-    assert item == Item(name="zdummy", size=SizeEnum.l)
+    item = await api.item.get({"item_name": "zdummy"})
+    assert item.is_ok()
+    assert item.unwrap() == Item(name="zdummy", size=SizeEnum.l)
 
-    with pytest.raises(HTTPError) as exc:
-        item = (await api.item.get({"item_name": "nonono"})).response
-    assert exc.value.status_code == 404
-    assert exc.value.json == {"detail": "Item not found"}
+    item = await api.item.get({"item_name": "nonono"})
+    assert item.is_err()
+    exc = item.unwrap_err()
+    assert exc.status_code == 404
+    assert exc.json == {"detail": "Item not found"}
 
     # Test delete
-    await api.item.delete({"item_name": "zdummy"})
+    item = await api.item.delete({"item_name": "zdummy"})
+    assert item.is_ok()
     items = await api.item.collection_get({})
+    assert items.is_ok()
     litems = list(items.unwrap())
     assert litems == [
         Item(name="dummy0", size=SizeEnum.s),
@@ -139,24 +151,29 @@ async def test_crud(dummy_api_endpoint: str):
     ]
 
     # Test patch
-    await api.item.patch({"item_name": "dummy1", "name": "dummy2"})
+    item = await api.item.patch({"item_name": "dummy1", "name": "dummy2"})
+    assert item.is_ok()
     items = await api.item.collection_get()
+    assert items.is_ok()
     litems = list(items.unwrap())
     assert litems == [
         Item(name="dummy0", size=SizeEnum.s),
         Item(name="dummy2", size=SizeEnum.m),
     ]
 
-    await api.item.patch({"item_name": "dummy2", "size": "L"})
+    op_result = await api.item.patch({"item_name": "dummy2", "size": "L"})
+    assert op_result.is_ok()
     items = await api.item.collection_get()
+    assert items.is_ok()
     litems = list(items.unwrap())
     assert litems == [
         Item(name="dummy0", size=SizeEnum.s),
         Item(name="dummy2", size=SizeEnum.l),
     ]
 
-    with pytest.raises(NoContractException) as exc:  # type: ignore
+    with pytest.raises(NoContractException) as no_contract_exc:
         await api.item.put({})
     assert (
-        str(exc.value) == "Unregistered route 'PUT' in resource 'item' in client 'api'"
+        str(no_contract_exc.value)
+        == "Unregistered route 'PUT' in resource 'item' in client 'api'"
     )

--- a/tests/unittests/_async/test_service_route_proxy.py
+++ b/tests/unittests/_async/test_service_route_proxy.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+from result import Result
 
 from blacksmith import Request
 from blacksmith.domain.exceptions import (
@@ -280,7 +281,9 @@ async def test_route_proxy_collection_get():
         collection_parser=CollectionParser,
         middlewares=[],
     )
-    resp: CollectionIterator[Any] = await proxy.collection_get()
+    result: Result[CollectionIterator[Any], HTTPError] = await proxy.collection_get()
+    assert result.is_ok()
+    resp = result.unwrap()
     assert resp.meta.total_count == 10
     assert resp.meta.count == 2
     lresp = list(resp)
@@ -312,7 +315,9 @@ async def test_route_proxy_collection_get_with_parser():
         collection_parser=CollectionParser,
         middlewares=[],
     )
-    resp: CollectionIterator[Any] = await proxy.collection_get()
+    result: Result[CollectionIterator[Any], HTTPError] = await proxy.collection_get()
+    assert result.is_ok()
+    resp = result.unwrap()
     assert resp.meta.total_count == 10
     assert resp.meta.count == 2
     lresp = list(resp)

--- a/tests/unittests/_async/test_service_route_proxy.py
+++ b/tests/unittests/_async/test_service_route_proxy.py
@@ -77,11 +77,13 @@ async def test_route_proxy_prepare_middleware(
             AsyncHTTPAddHeadersMiddleware({"Eggs": "egg"}),
         ],
     )
-    resp = await proxy._handle_req_with_middlewares(
+    result = await proxy._handle_req_with_middlewares(
         dummy_http_request,
         HTTPTimeout(4.2),
         "/",
     )
+    assert result.is_ok()
+    resp = result.unwrap()
     assert resp.headers == {
         "Authorization": "Bearer abc",
         "X-Req-Id": "42",

--- a/tests/unittests/_sync/test_service_route_proxy.py
+++ b/tests/unittests/_sync/test_service_route_proxy.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+from result import Result
 
 from blacksmith import Request
 from blacksmith.domain.exceptions import (
@@ -280,7 +281,9 @@ def test_route_proxy_collection_get():
         collection_parser=CollectionParser,
         middlewares=[],
     )
-    resp: CollectionIterator[Any] = proxy.collection_get()
+    result: Result[CollectionIterator[Any], HTTPError] = proxy.collection_get()
+    assert result.is_ok()
+    resp = result.unwrap()
     assert resp.meta.total_count == 10
     assert resp.meta.count == 2
     lresp = list(resp)
@@ -312,7 +315,9 @@ def test_route_proxy_collection_get_with_parser():
         collection_parser=CollectionParser,
         middlewares=[],
     )
-    resp: CollectionIterator[Any] = proxy.collection_get()
+    result: Result[CollectionIterator[Any], HTTPError] = proxy.collection_get()
+    assert result.is_ok()
+    resp = result.unwrap()
     assert resp.meta.total_count == 10
     assert resp.meta.count == 2
     lresp = list(resp)

--- a/tests/unittests/_sync/test_service_route_proxy.py
+++ b/tests/unittests/_sync/test_service_route_proxy.py
@@ -77,11 +77,13 @@ def test_route_proxy_prepare_middleware(
             SyncHTTPAddHeadersMiddleware({"Eggs": "egg"}),
         ],
     )
-    resp = proxy._handle_req_with_middlewares(
+    result = proxy._handle_req_with_middlewares(
         dummy_http_request,
         HTTPTimeout(4.2),
         "/",
     )
+    assert result.is_ok()
+    resp = result.unwrap()
     assert resp.headers == {
         "Authorization": "Bearer abc",
         "X-Req-Id": "42",

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -241,12 +241,20 @@ def test_response_box_no_schema():
         "api",
     )
     with pytest.raises(NoResponseSchemaException) as ctx:
-        assert resp.response
+        assert resp.unwrap()
+
+    with warnings.catch_warnings(record=True) as ctx_warn:
+        warnings.simplefilter("always")
+        with pytest.raises(NoResponseSchemaException) as ctx:
+            assert resp.response
     assert (
         str(ctx.value)
         == "No response schema in route 'GET /dummies' in resource'Dummy' "
         "in client 'api'"
     )
+    assert [str(w.message) for w in ctx_warn] == [
+        ".response is deprecated, use .unwrap() instead"
+    ]
 
 
 def test_collection_iterator():

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -251,22 +251,20 @@ def test_response_box_no_schema():
 
 def test_collection_iterator():
     collec: CollectionIterator[Any] = CollectionIterator(
-        Ok(
-            HTTPResponse(
-                200,
-                {"Total-Count": "5"},
-                [
-                    {
-                        "name": "Alice",
-                        "age": 24,
-                        "useless": True,
-                    },
-                    {
-                        "name": "Bob",
-                        "age": 42,
-                    },
-                ],
-            )
+        HTTPResponse(
+            200,
+            {"Total-Count": "5"},
+            [
+                {
+                    "name": "Alice",
+                    "age": 24,
+                    "useless": True,
+                },
+                {
+                    "name": "Bob",
+                    "age": 42,
+                },
+            ],
         ),
         GetResponse,
         CollectionParser,

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -137,10 +137,14 @@ def test_response_box():
     alice = GetResponse(name="Alice", age=24)
     bob = GetResponse(name="Bob", age=40)
     assert resp.is_ok()
+    assert resp.is_err() is False
     assert resp.unwrap() == alice
     with pytest.raises(UnwrapError):
         assert resp.unwrap_err()
+
+    assert resp.unwrap_or(bob) == alice
     assert resp.unwrap_or_else(lambda err: bob) == alice
+
     assert resp.expect("To never fail") == alice
     with pytest.raises(UnwrapError):
         assert resp.expect_err("To always fail")
@@ -156,6 +160,7 @@ def test_response_box():
 
 
 def test_response_box_err():
+    bob = GetResponse(name="Bob", age=40)
     http_error = HTTPError(
         "500 Internal Server Error",
         HTTPRequest("GET", "/", {}, {}, {}),
@@ -176,11 +181,13 @@ def test_response_box_err():
         "",
     )
     assert resp.is_err()
+    assert resp.is_ok() is False
     assert resp.unwrap_err() == http_error
     assert resp.json == {"message": "Internal Server Error"}
-    assert resp.unwrap_or_else(
-        lambda err: GetResponse(name="Bob", age=40)
-    ) == GetResponse(name="Bob", age=40)
+
+    assert resp.unwrap_or(bob) == bob
+    assert resp.unwrap_or_else(lambda err: bob) == bob
+
     with pytest.raises(UnwrapError):
         assert resp.expect("To never fail")
     assert resp.expect_err("To always fail") == http_error

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 import pytest
+from result import Ok
 
 from blacksmith.domain.exceptions import NoResponseSchemaException
 from blacksmith.domain.model import (
@@ -115,14 +116,16 @@ def test_collection_parser():
 
 def test_response_box():
     resp = ResponseBox(
-        HTTPResponse(
-            200,
-            {},
-            {
-                "name": "Alice",
-                "age": 24,
-                "useless": True,
-            },
+        Ok(
+            HTTPResponse(
+                200,
+                {},
+                {
+                    "name": "Alice",
+                    "age": 24,
+                    "useless": True,
+                },
+            )
         ),
         GetResponse,
         "GET",
@@ -136,14 +139,16 @@ def test_response_box():
 
 def test_response_box_no_schema():
     resp = ResponseBox(
-        HTTPResponse(
-            200,
-            {},
-            {
-                "name": "Alice",
-                "age": 24,
-                "useless": True,
-            },
+        Ok(
+            HTTPResponse(
+                200,
+                {},
+                {
+                    "name": "Alice",
+                    "age": 24,
+                    "useless": True,
+                },
+            )
         ),
         None,
         "GET",
@@ -162,20 +167,22 @@ def test_response_box_no_schema():
 
 def test_collection_iterator():
     collec: CollectionIterator[Any] = CollectionIterator(
-        HTTPResponse(
-            200,
-            {"Total-Count": "5"},
-            [
-                {
-                    "name": "Alice",
-                    "age": 24,
-                    "useless": True,
-                },
-                {
-                    "name": "Bob",
-                    "age": 42,
-                },
-            ],
+        Ok(
+            HTTPResponse(
+                200,
+                {"Total-Count": "5"},
+                [
+                    {
+                        "name": "Alice",
+                        "age": 24,
+                        "useless": True,
+                    },
+                    {
+                        "name": "Bob",
+                        "age": 42,
+                    },
+                ],
+            )
         ),
         GetResponse,
         CollectionParser,

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -145,6 +145,12 @@ def test_response_box():
     assert resp.unwrap_or(bob) == alice
     assert resp.unwrap_or_else(lambda err: bob) == alice
 
+    assert resp.map(lambda x: x.name) == Ok("Alice")  # type: ignore
+    assert resp.map_or("Bob", lambda x: x.name) == "Alice"  # type: ignore
+    assert resp.map_or_else(lambda: "Bob", lambda x: x.name) == "Alice"  # type: ignore
+
+    assert resp.map_err(lambda err: err.status_code) == Ok(alice)  # type: ignore
+
     assert resp.expect("To never fail") == alice
     with pytest.raises(UnwrapError):
         assert resp.expect_err("To always fail")
@@ -187,6 +193,12 @@ def test_response_box_err():
 
     assert resp.unwrap_or(bob) == bob
     assert resp.unwrap_or_else(lambda err: bob) == bob
+
+    assert resp.map(lambda x: x.name) == Err(http_error)  # type: ignore
+    assert resp.map_or("Bob", lambda x: x.name) == "Bob"  # type: ignore
+    assert resp.map_or_else(lambda: "Bob", lambda x: x.name) == "Bob"  # type: ignore
+
+    assert resp.map_err(lambda err: err.status_code) == Err(500)  # type: ignore
 
     with pytest.raises(UnwrapError):
         assert resp.expect("To never fail")

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -148,8 +148,10 @@ def test_response_box():
     assert resp.map(lambda x: x.name) == Ok("Alice")  # type: ignore
     assert resp.map_or("Bob", lambda x: x.name) == "Alice"  # type: ignore
     assert resp.map_or_else(lambda: "Bob", lambda x: x.name) == "Alice"  # type: ignore
-
     assert resp.map_err(lambda err: err.status_code) == Ok(alice)  # type: ignore
+
+    assert resp.and_then(lambda x: x.name) == "Alice"  # type: ignore
+    assert resp.or_else(lambda err: err.status_code) == Ok(alice)  # type: ignore
 
     assert resp.expect("To never fail") == alice
     with pytest.raises(UnwrapError):
@@ -197,8 +199,10 @@ def test_response_box_err():
     assert resp.map(lambda x: x.name) == Err(http_error)  # type: ignore
     assert resp.map_or("Bob", lambda x: x.name) == "Bob"  # type: ignore
     assert resp.map_or_else(lambda: "Bob", lambda x: x.name) == "Bob"  # type: ignore
-
     assert resp.map_err(lambda err: err.status_code) == Err(500)  # type: ignore
+
+    assert resp.and_then(lambda x: x.name) == Err(http_error)  # type: ignore
+    assert resp.or_else(lambda err: err.status_code) == 500  # type: ignore
 
     with pytest.raises(UnwrapError):
         assert resp.expect("To never fail")

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -134,13 +134,16 @@ def test_response_box():
         "",
         "",
     )
+    alice = GetResponse(name="Alice", age=24)
+    bob = GetResponse(name="Bob", age=40)
     assert resp.is_ok()
-    assert resp.unwrap().dict() == {"age": 24, "name": "Alice"}
+    assert resp.unwrap() == alice
     with pytest.raises(UnwrapError):
         assert resp.unwrap_err()
-    assert resp.unwrap_or_else(
-        lambda err: GetResponse(name="Bob", age=40)
-    ) == GetResponse(name="Alice", age=24)
+    assert resp.unwrap_or_else(lambda err: bob) == alice
+    assert resp.expect("To never fail") == alice
+    with pytest.raises(UnwrapError):
+        assert resp.expect_err("To always fail")
 
     with warnings.catch_warnings(record=True) as ctx:
         warnings.simplefilter("always")
@@ -178,6 +181,9 @@ def test_response_box_err():
     assert resp.unwrap_or_else(
         lambda err: GetResponse(name="Bob", age=40)
     ) == GetResponse(name="Bob", age=40)
+    with pytest.raises(UnwrapError):
+        assert resp.expect("To never fail")
+    assert resp.expect_err("To always fail") == http_error
 
     with warnings.catch_warnings(record=True) as ctx_warn:
         warnings.simplefilter("always")


### PR DESCRIPTION
# /!\ API Break 

This pull request change the response type on all method to wrap response in a "Result" object.

As a result, we have:

* the same API for the collection and non collection result.
* No exception raised to control the http error flow.
  * there are still a lot of exception raised for registration, contracts and so on that appears only while developping, integrating API

```
    api = await cli("gandi")
    if len(sys.argv) == 2:
        domain = sys.argv[1]
        domain_result = await api.domain.get(DomainParam(name=domain))
        domain = domain_result.unwrap()
        print(domain)
    else:
        domain_result = await api.domain.collection_get()
        domains = domain_result.unwrap()
        print(domains.meta)
        print()
        for domain in domains:
            print(domain)

```

 * [x] Update the code
 * [x] Update examples code
 * [x] Update the documentation


Fixes #30 