### PR TITLE
Use Consul Node Address if Service Address is missing

### DIFF
--- a/src/blacksmith/sd/_async/adapters/consul.py
+++ b/src/blacksmith/sd/_async/adapters/consul.py
@@ -4,7 +4,7 @@ The discovery based on :term:`Consul`.
 This driver implement a client side service discovery.
 """
 import random
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Optional
 
 from pydantic.fields import Field
 from result import Result
@@ -37,10 +37,16 @@ class ServiceRequest(Request):
 class Service(Response):
     """Consul Service response."""
 
-    address: str = Field(alias="ServiceAddress")
-    """IP Address of an instance that host the service."""
+    node_address: str = Field(alias="Address")
+    """IP address of the Consul node on which the service is registered."""
+    service_address: Optional[str] = Field(alias="ServiceAddress")
+    """IP address of the service host. if empty, node address is used."""
     port: int = Field(alias="ServicePort")
     """TCP Port of an instance that host the service."""
+
+    @property
+    def address(self) -> str:
+        return self.service_address or self.node_address
 
 
 _registry = Registry()

--- a/src/blacksmith/sd/_sync/adapters/consul.py
+++ b/src/blacksmith/sd/_sync/adapters/consul.py
@@ -4,7 +4,7 @@ The discovery based on :term:`Consul`.
 This driver implement a client side service discovery.
 """
 import random
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Optional
 
 from pydantic.fields import Field
 from result import Result
@@ -37,10 +37,16 @@ class ServiceRequest(Request):
 class Service(Response):
     """Consul Service response."""
 
-    address: str = Field(alias="ServiceAddress")
-    """IP Address of an instance that host the service."""
+    node_address: str = Field(alias="Address")
+    """IP address of the Consul node on which the service is registered."""
+    service_address: Optional[str] = Field(alias="ServiceAddress")
+    """IP address of the service host. if empty, node address is used."""
     port: int = Field(alias="ServicePort")
     """TCP Port of an instance that host the service."""
+
+    @property
+    def address(self) -> str:
+        return self.service_address or self.node_address
 
 
 _registry = Registry()

--- a/tests/unittests/_async/test_sd.py
+++ b/tests/unittests/_async/test_sd.py
@@ -59,14 +59,49 @@ async def test_consul_discovery_get_endpoint(consul_sd: AsyncConsulDiscovery):
 
 async def test_consul_discovery_resolve(consul_sd: AsyncConsulDiscovery):
     service = await consul_sd.resolve("dummy", "v1")
-    assert service == Service(ServiceAddress="8.8.8.8", ServicePort=1234)
+    assert service == Service(
+        Address="1.1.1.1", ServiceAddress="8.8.8.8", ServicePort=1234
+    )
 
 
 async def test_consul_discovery_resolve_unversionned_endpoint(
     consul_sd: AsyncConsulDiscovery,
 ):
     service = await consul_sd.resolve("dummy", None)
-    assert service == Service(ServiceAddress="8.8.8.8", ServicePort=1234)
+    assert service == Service(
+        Address="1.1.1.1", ServiceAddress="8.8.8.8", ServicePort=1234
+    )
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {
+            "Address": "2.2.2.2",
+            "ServiceAddress": "1.1.1.1",
+            "ServicePort": 1234,
+        },
+        {
+            "Address": "1.1.1.1",
+            "ServiceAddress": "",
+            "ServicePort": 1234,
+        },
+        {
+            "Address": "1.1.1.1",
+            "ServicePort": 1234,
+        },
+        {
+            "Address": "1.1.1.1",
+            "ServiceAddress": None,
+            "ServicePort": 1234,
+        },
+    ],
+)
+async def test_consul_discovery_resolve_address(
+    consul_sd_with_body: AsyncConsulDiscovery,
+):
+    service = await consul_sd_with_body.resolve("dummy", None)
+    assert service.address == "1.1.1.1"
 
 
 async def test_consul_discovery_resolve_unregistered(consul_sd: AsyncConsulDiscovery):

--- a/tests/unittests/_sync/test_sd.py
+++ b/tests/unittests/_sync/test_sd.py
@@ -59,14 +59,49 @@ def test_consul_discovery_get_endpoint(consul_sd: SyncConsulDiscovery):
 
 def test_consul_discovery_resolve(consul_sd: SyncConsulDiscovery):
     service = consul_sd.resolve("dummy", "v1")
-    assert service == Service(ServiceAddress="8.8.8.8", ServicePort=1234)
+    assert service == Service(
+        Address="1.1.1.1", ServiceAddress="8.8.8.8", ServicePort=1234
+    )
 
 
 def test_consul_discovery_resolve_unversionned_endpoint(
     consul_sd: SyncConsulDiscovery,
 ):
     service = consul_sd.resolve("dummy", None)
-    assert service == Service(ServiceAddress="8.8.8.8", ServicePort=1234)
+    assert service == Service(
+        Address="1.1.1.1", ServiceAddress="8.8.8.8", ServicePort=1234
+    )
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {
+            "Address": "2.2.2.2",
+            "ServiceAddress": "1.1.1.1",
+            "ServicePort": 1234,
+        },
+        {
+            "Address": "1.1.1.1",
+            "ServiceAddress": "",
+            "ServicePort": 1234,
+        },
+        {
+            "Address": "1.1.1.1",
+            "ServicePort": 1234,
+        },
+        {
+            "Address": "1.1.1.1",
+            "ServiceAddress": None,
+            "ServicePort": 1234,
+        },
+    ],
+)
+def test_consul_discovery_resolve_address(
+    consul_sd_with_body: SyncConsulDiscovery,
+):
+    service = consul_sd_with_body.resolve("dummy", None)
+    assert service.address == "1.1.1.1"
 
 
 def test_consul_discovery_resolve_unregistered(consul_sd: SyncConsulDiscovery):


### PR DESCRIPTION
Fixes #43

Use [node address](https://developer.hashicorp.com/consul/api-docs/catalog#address-1)
if [service address](https://developer.hashicorp.com/consul/api-docs/catalog#serviceaddress)
is missing.