### PR TITLE
Fix url serialization

### DIFF
--- a/src/blacksmith/service/http_body_serializer.py
+++ b/src/blacksmith/service/http_body_serializer.py
@@ -3,11 +3,13 @@ import json
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     List,
     Mapping,
     Optional,
     Sequence,
+    Type,
     Union,
     cast,
 )
@@ -29,7 +31,13 @@ from blacksmith.typing import HttpLocation, HTTPMethod, Json, Url
 # assume we can use deprecated stuff until we support both version
 try:
     # pydantic 2
-    from pydantic.deprecated.json import ENCODERS_BY_TYPE  # type: ignore
+    from pydantic.deprecated.json import ENCODERS_BY_TYPE as BASE_TYPES  # type: ignore
+    from pydantic_core import Url as PydanticUrl
+
+    ENCODERS_BY_TYPE: Mapping[Type[Any], Callable[[Any], Any]] = {
+        PydanticUrl: str,
+        **BASE_TYPES,
+    }
 except ImportError:  # type: ignore # coverage: ignore
     # pydantic 1
     from pydantic.json import ENCODERS_BY_TYPE  # type: ignore  # coverage: ignore

--- a/tests/unittests/test_http_body_serializer.py
+++ b/tests/unittests/test_http_body_serializer.py
@@ -233,7 +233,18 @@ def test_serialize_request_body(params: Mapping[str, Any]):
                 "content_type": "application/json",
                 "expected": '{"url": "http://mardiros.github.io/"}',
             },
-            id="url type",
+            id="bared url",
+        ),
+        pytest.param(
+            {
+                "req": DummyPostRequestTypes(
+                    url=HttpUrl("https://mardiros.github.io/blacksmith")
+                ),
+                "body": {"url"},
+                "content_type": "application/json",
+                "expected": '{"url": "https://mardiros.github.io/blacksmith"}',
+            },
+            id="url type with path",
         ),
     ],
 )

--- a/tests/unittests/test_http_body_serializer.py
+++ b/tests/unittests/test_http_body_serializer.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any, Dict, Mapping, Optional, Sequence, Union
 
 import pytest
-from pydantic import SecretStr
+from pydantic import HttpUrl, SecretStr
 
 from blacksmith import (
     HeaderField,
@@ -44,6 +44,10 @@ class DummyGetRequest(Request):
 
 class DummyPostRequest(DummyGetRequest):
     foo: str = PostBodyField()
+
+
+class DummyPostRequestTypes(Request):
+    url: HttpUrl = PostBodyField()
 
 
 class DummyHTTPRepsonse(HTTPRawResponse):
@@ -215,6 +219,25 @@ def test_serialize_part_default_with_none() -> None:
     ],
 )
 def test_serialize_request_body(params: Mapping[str, Any]):
+    body = serialize_request_body(params["req"], params["body"], params["content_type"])
+    assert body == params["expected"]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.param(
+            {
+                "req": DummyPostRequestTypes(url=HttpUrl("http://mardiros.github.io")),
+                "body": {"url"},
+                "content_type": "application/json",
+                "expected": '{"url": "http://mardiros.github.io/"}',
+            },
+            id="url type",
+        ),
+    ],
+)
+def test_serialize_request_body_pydantic_2(params: Mapping[str, Any]):
     body = serialize_request_body(params["req"], params["body"], params["content_type"])
     assert body == params["expected"]
 


### PR DESCRIPTION
The HttpUrl type has been updated in pydantic 2 and now it is not json serializable with the JsonEncoder.

The code is still compatibible with pydantic 1 without any guaranty by the unit test suite, since it's only run with 

pydantic 2 at the moment.