### PR TITLE
Fix response types

### DIFF
--- a/src/blacksmith/domain/model/params.py
+++ b/src/blacksmith/domain/model/params.py
@@ -53,8 +53,8 @@ class Request(BaseModel):
     """
 
 
-TResponse = TypeVar("TResponse", bound="Response")
-TCollectionResponse = TypeVar("TCollectionResponse", bound="Response")
+TResponse = TypeVar("TResponse", bound="Optional[Response]")
+TCollectionResponse = TypeVar("TCollectionResponse", bound="Optional[Response]")
 
 
 class Response(BaseModel):


### PR DESCRIPTION
The response is optional, so the bound model has to be optional