### PR TITLE
Add a service discovery adapter for Nomad and Consul Connect

### DIFF
--- a/docs/source/develop/sd/nomad.rst
+++ b/docs/source/develop/sd/nomad.rst
@@ -1,0 +1,5 @@
+Nomad
+=====
+
+.. automodule:: blacksmith.sd._async.adapters.nomad
+   :members:

--- a/docs/source/user/sd/sd_nomad.sync.py
+++ b/docs/source/user/sd/sd_nomad.sync.py
@@ -1,0 +1,7 @@
+from blacksmith import SyncNomadDiscovery
+
+# no parameter needed, discovery use environment variables.
+sd = SyncNomadDiscovery()
+
+# no version needed, only the service name
+service = sd.get_endpoint("service_name")

--- a/docs/source/user/sd/sd_nomad_async.py
+++ b/docs/source/user/sd/sd_nomad_async.py
@@ -1,0 +1,7 @@
+from blacksmith import AsyncNomadDiscovery
+
+# no parameter needed, discovery use environment variables.
+sd = AsyncNomadDiscovery()
+
+# no version needed, only the service name
+service = sd.get_endpoint("service_name")

--- a/docs/source/user/sd/service_discovery.rst
+++ b/docs/source/user/sd/service_discovery.rst
@@ -1,7 +1,7 @@
 Service Discovery
 =================
 
-While consuming a lot of different API, the problem to solve is to 
+While consuming a lot of different API, the problem to solve is to
 simplify the registration of services and its discoverability.
 
 So the first approach is to have a static discovery, like we have
@@ -72,6 +72,25 @@ Sync
    https://github.com/mardiros/blacksmith/tree/master/examples/consul_sd
 
 
+Nomad Example
+~~~~~~~~~~~~~
+
+When using Consul Connect in a Nomad cluster, upstreams declared in a jobspec
+make available a mTLS connection on a `local_bind_port`. Addresses of these
+services are injected as environment variables during deployment of the job.
+
+Async
+~~~~~
+
+.. literalinclude:: sd_nomad_async.py
+
+Sync
+~~~~~
+
+.. literalinclude:: sd_nomad_sync.py
+
+
+
 Server Side Service Discovery
 -----------------------------
 
@@ -106,4 +125,3 @@ Sync
    **Take a look at the example!**
 
    https://github.com/mardiros/blacksmith/tree/master/examples/consul_template_sd
-

--- a/src/blacksmith/__init__.py
+++ b/src/blacksmith/__init__.py
@@ -53,12 +53,14 @@ from .middleware._sync import (
 from .sd._async import (
     AsyncAbstractServiceDiscovery,
     AsyncConsulDiscovery,
+    AsyncNomadDiscovery,
     AsyncRouterDiscovery,
     AsyncStaticDiscovery,
 )
 from .sd._sync import (
     SyncAbstractServiceDiscovery,
     SyncConsulDiscovery,
+    SyncNomadDiscovery,
     SyncRouterDiscovery,
     SyncStaticDiscovery,
 )
@@ -113,6 +115,8 @@ __all__ = [
     "SyncAbstractServiceDiscovery",
     "AsyncConsulDiscovery",
     "SyncConsulDiscovery",
+    "AsyncNomadDiscovery",
+    "SyncNomadDiscovery",
     "AsyncRouterDiscovery",
     "SyncRouterDiscovery",
     "AsyncStaticDiscovery",

--- a/src/blacksmith/sd/_async/__init__.py
+++ b/src/blacksmith/sd/_async/__init__.py
@@ -1,4 +1,5 @@
 from .adapters.consul import AsyncConsulDiscovery
+from .adapters.nomad import AsyncNomadDiscovery
 from .adapters.router import AsyncRouterDiscovery
 from .adapters.static import AsyncStaticDiscovery
 from .base import AsyncAbstractServiceDiscovery
@@ -6,6 +7,7 @@ from .base import AsyncAbstractServiceDiscovery
 __all__ = [
     "AsyncAbstractServiceDiscovery",
     "AsyncConsulDiscovery",
+    "AsyncNomadDiscovery",
     "AsyncRouterDiscovery",
     "AsyncStaticDiscovery",
 ]

--- a/src/blacksmith/sd/_async/adapters/nomad.py
+++ b/src/blacksmith/sd/_async/adapters/nomad.py
@@ -1,6 +1,6 @@
 """
 
-The Nomad discovery strategy use environment variables injected to discover
+The Nomad discovery strategy uses environment variables injected to discover
 Consul Connect services, thus defined as upstreams to an application.
 """
 

--- a/src/blacksmith/sd/_async/adapters/nomad.py
+++ b/src/blacksmith/sd/_async/adapters/nomad.py
@@ -1,0 +1,27 @@
+"""
+
+The Nomad discovery strategy use environment variables injected to discover
+Consul Connect services, thus defined as upstreams to an application.
+"""
+
+import os
+
+from blacksmith.domain.exceptions import UnregisteredServiceException
+from blacksmith.typing import ServiceName, Version
+
+from ..base import AsyncAbstractServiceDiscovery, Url
+
+
+class AsyncNomadDiscovery(AsyncAbstractServiceDiscovery):
+    """
+    A discovery instance based on Nomad environment variables.
+    """
+
+    async def get_endpoint(self, service: ServiceName, version: Version) -> Url:
+        """
+        Retrieve endpoint using the given parameters from `endpoints`.
+        """
+        env_addr: str = os.getenv(f"NOMAD_UPSTREAM_ADDR_{service}")
+        if not env_addr:
+            raise UnregisteredServiceException(service, version)
+        return f"http://{env_addr}"

--- a/src/blacksmith/sd/_async/adapters/nomad.py
+++ b/src/blacksmith/sd/_async/adapters/nomad.py
@@ -17,7 +17,7 @@ class AsyncNomadDiscovery(AsyncAbstractServiceDiscovery):
     A discovery instance based on Nomad environment variables.
     """
 
-    async def get_endpoint(self, service: ServiceName, version: Version) -> Url:
+    async def get_endpoint(self, service: ServiceName, version: Version = None) -> Url:
         """
         Retrieve endpoint using the given parameters from `endpoints`.
         """

--- a/src/blacksmith/sd/_sync/__init__.py
+++ b/src/blacksmith/sd/_sync/__init__.py
@@ -1,4 +1,5 @@
 from .adapters.consul import SyncConsulDiscovery
+from .adapters.nomad import SyncNomadDiscovery
 from .adapters.router import SyncRouterDiscovery
 from .adapters.static import SyncStaticDiscovery
 from .base import SyncAbstractServiceDiscovery
@@ -6,6 +7,7 @@ from .base import SyncAbstractServiceDiscovery
 __all__ = [
     "SyncAbstractServiceDiscovery",
     "SyncConsulDiscovery",
+    "SyncNomadDiscovery",
     "SyncRouterDiscovery",
     "SyncStaticDiscovery",
 ]

--- a/src/blacksmith/sd/_sync/adapters/nomad.py
+++ b/src/blacksmith/sd/_sync/adapters/nomad.py
@@ -1,0 +1,27 @@
+"""
+
+The Nomad discovery strategy use environment variables injected to discover
+Consul Connect services, thus defined as upstreams to an application.
+"""
+
+import os
+
+from blacksmith.domain.exceptions import UnregisteredServiceException
+from blacksmith.typing import ServiceName, Version
+
+from ..base import SyncAbstractServiceDiscovery, Url
+
+
+class SyncNomadDiscovery(SyncAbstractServiceDiscovery):
+    """
+    A discovery instance based on Nomad environment variables.
+    """
+
+    def get_endpoint(self, service: ServiceName, version: Version) -> Url:
+        """
+        Retrieve endpoint using the given parameters from `endpoints`.
+        """
+        env_addr: str = os.getenv(f"NOMAD_UPSTREAM_ADDR_{service}")
+        if not env_addr:
+            raise UnregisteredServiceException(service, version)
+        return f"http://{env_addr}"

--- a/src/blacksmith/sd/_sync/adapters/nomad.py
+++ b/src/blacksmith/sd/_sync/adapters/nomad.py
@@ -1,6 +1,6 @@
 """
 
-The Nomad discovery strategy use environment variables injected to discover
+The Nomad discovery strategy uses environment variables injected to discover
 Consul Connect services, thus defined as upstreams to an application.
 """
 

--- a/src/blacksmith/sd/_sync/adapters/nomad.py
+++ b/src/blacksmith/sd/_sync/adapters/nomad.py
@@ -17,7 +17,7 @@ class SyncNomadDiscovery(SyncAbstractServiceDiscovery):
     A discovery instance based on Nomad environment variables.
     """
 
-    def get_endpoint(self, service: ServiceName, version: Version) -> Url:
+    def get_endpoint(self, service: ServiceName, version: Version = None) -> Url:
         """
         Retrieve endpoint using the given parameters from `endpoints`.
         """

--- a/tests/unittests/_async/conftest.py
+++ b/tests/unittests/_async/conftest.py
@@ -11,6 +11,7 @@ from blacksmith.middleware._async.auth import AsyncHTTPAuthorizationMiddleware
 from blacksmith.middleware._async.base import AsyncHTTPAddHeadersMiddleware
 from blacksmith.middleware._async.http_cache import AsyncAbstractCache
 from blacksmith.sd._async.adapters.consul import AsyncConsulDiscovery, _registry
+from blacksmith.sd._async.adapters.nomad import AsyncNomadDiscovery
 from blacksmith.sd._async.adapters.router import AsyncRouterDiscovery
 from blacksmith.sd._async.adapters.static import AsyncStaticDiscovery, Endpoints
 from blacksmith.service._async.base import AsyncAbstractTransport
@@ -177,6 +178,11 @@ def consul_sd() -> AsyncConsulDiscovery:
 
 
 @pytest.fixture
+def nomad_sd() -> AsyncNomadDiscovery:
+    return AsyncNomadDiscovery()
+
+
+@pytest.fixture
 def router_sd() -> AsyncRouterDiscovery:
     return AsyncRouterDiscovery()
 
@@ -211,7 +217,7 @@ def fake_http_middleware_cache() -> AsyncFakeHttpMiddlewareCache:
 
 @pytest.fixture
 def fake_http_middleware_cache_with_data(
-    params: Mapping[str, Any]
+    params: Mapping[str, Any],
 ) -> AsyncFakeHttpMiddlewareCache:
     return AsyncFakeHttpMiddlewareCache(params["initial_cache"])
 

--- a/tests/unittests/_async/test_sd.py
+++ b/tests/unittests/_async/test_sd.py
@@ -138,7 +138,7 @@ async def test_nomad_resolve_dummy(nomad_sd: AsyncNomadDiscovery, monkeypatch):
     assert endpoint == "http://127.0.0.1:8000"
 
 
-async def test_nomad_resolve_dummy_noversion(nomad_sd: AsyncNomadDiscovery, monkeypatch):
+async def test_nomad_resolve_dummy_nover(nomad_sd: AsyncNomadDiscovery, monkeypatch):
     monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
     endpoint: str = await nomad_sd.get_endpoint("dummy")
     assert endpoint == "http://127.0.0.1:8000"

--- a/tests/unittests/_sync/conftest.py
+++ b/tests/unittests/_sync/conftest.py
@@ -11,6 +11,7 @@ from blacksmith.middleware._sync.auth import SyncHTTPAuthorizationMiddleware
 from blacksmith.middleware._sync.base import SyncHTTPAddHeadersMiddleware
 from blacksmith.middleware._sync.http_cache import SyncAbstractCache
 from blacksmith.sd._sync.adapters.consul import SyncConsulDiscovery, _registry
+from blacksmith.sd._sync.adapters.nomad import SyncNomadDiscovery
 from blacksmith.sd._sync.adapters.router import SyncRouterDiscovery
 from blacksmith.sd._sync.adapters.static import Endpoints, SyncStaticDiscovery
 from blacksmith.service._sync.base import SyncAbstractTransport
@@ -177,6 +178,11 @@ def consul_sd() -> SyncConsulDiscovery:
 
 
 @pytest.fixture
+def nomad_sd() -> SyncNomadDiscovery:
+    return SyncNomadDiscovery()
+
+
+@pytest.fixture
 def router_sd() -> SyncRouterDiscovery:
     return SyncRouterDiscovery()
 
@@ -211,7 +217,7 @@ def fake_http_middleware_cache() -> SyncFakeHttpMiddlewareCache:
 
 @pytest.fixture
 def fake_http_middleware_cache_with_data(
-    params: Mapping[str, Any]
+    params: Mapping[str, Any],
 ) -> SyncFakeHttpMiddlewareCache:
     return SyncFakeHttpMiddlewareCache(params["initial_cache"])
 

--- a/tests/unittests/_sync/test_sd.py
+++ b/tests/unittests/_sync/test_sd.py
@@ -8,6 +8,7 @@ from blacksmith.sd._sync.adapters.consul import (
     SyncConsulDiscovery,
     blacksmith_cli,
 )
+from blacksmith.sd._sync.adapters.nomad import SyncNomadDiscovery
 from blacksmith.sd._sync.adapters.router import SyncRouterDiscovery
 from blacksmith.sd._sync.adapters.static import SyncStaticDiscovery
 
@@ -129,6 +130,12 @@ def test_consul_resolve_consul_error(consul_sd: SyncConsulDiscovery):
     with pytest.raises(ConsulApiError) as ctx:
         consul_sd.resolve("dummy", "v3")
     assert str(ctx.value) == "422 Unprocessable entity"
+
+
+def test_nomad_resolve(nomad_sd: SyncNomadDiscovery, monkeypatch):
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
+    endpoint: str = nomad_sd.get_endpoint("dummy", "v1")
+    assert endpoint == "http://127.0.0.1:8000"
 
 
 def test_router_sd_get_endpoint_versionned(router_sd: SyncRouterDiscovery):

--- a/tests/unittests/_sync/test_sd.py
+++ b/tests/unittests/_sync/test_sd.py
@@ -132,10 +132,22 @@ def test_consul_resolve_consul_error(consul_sd: SyncConsulDiscovery):
     assert str(ctx.value) == "422 Unprocessable entity"
 
 
-def test_nomad_resolve(nomad_sd: SyncNomadDiscovery, monkeypatch):
+def test_nomad_resolve_dummy(nomad_sd: SyncNomadDiscovery, monkeypatch):
     monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
     endpoint: str = nomad_sd.get_endpoint("dummy", "v1")
     assert endpoint == "http://127.0.0.1:8000"
+
+
+def test_nomad_resolve_dummy_noversion(nomad_sd: SyncNomadDiscovery, monkeypatch):
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
+    endpoint: str = nomad_sd.get_endpoint("dummy")
+    assert endpoint == "http://127.0.0.1:8000"
+
+
+def test_nomad_resolve_unregistered(nomad_sd: SyncNomadDiscovery):
+    with pytest.raises(UnregisteredServiceException) as ctx:
+        nomad_sd.get_endpoint("dummy", "v2")
+    assert str(ctx.value) == "Unregistered service 'dummy/v2'"
 
 
 def test_router_sd_get_endpoint_versionned(router_sd: SyncRouterDiscovery):


### PR DESCRIPTION
When using Nomad and Consul Connect for mTLS communication between services, the endpoint is discovered using environment variables injected in a running container.

This pull request add an adapter for such service discovery.