### PR TITLE
Features/nomad version

### DIFF
--- a/src/blacksmith/sd/_async/adapters/consul.py
+++ b/src/blacksmith/sd/_async/adapters/consul.py
@@ -73,17 +73,20 @@ class AsyncConsulDiscovery(AsyncAbstractServiceDiscovery):
     """
     A discovery instance based on a :term:`Consul` server.
 
-    :param service_name_fmt: pattern for name of versionned service
-    :param service_url_fmt: pattern for url of versionned service
-    :param unversioned_service_name_fmt: pattern for name of unversioned service
-    :param unversioned_service_url_fmt: pattern for url of unversioned service
-
+    :param addr: endpoint of the consul v1 http api.
+    :param service_name_fmt: pattern for name of versionned service.
+    :param service_url_fmt: pattern for url of versionned service.
+    :param unversioned_service_name_fmt: pattern for name of unversioned service.
+    :param unversioned_service_url_fmt: pattern for url of unversioned service.
+    :param consul_token: If set, the consul token is sent on http api call.
     """
 
+    addr: str
     service_name_fmt: str
     service_url_fmt: str
     unversioned_service_name_fmt: str
     unversioned_service_url_fmt: str
+    consul_token: str
 
     def __init__(
         self,

--- a/src/blacksmith/sd/_async/adapters/nomad.py
+++ b/src/blacksmith/sd/_async/adapters/nomad.py
@@ -17,11 +17,28 @@ class AsyncNomadDiscovery(AsyncAbstractServiceDiscovery):
     A discovery instance based on Nomad environment variables.
     """
 
+    def __init__(
+        self,
+        service_url_fmt: str = "http://{nomad_upstream_addr}/{version}",
+        service_env_fmt: str = "NOMAD_UPSTREAM_ADDR_{service}-{version}",
+        unversioned_service_url_fmt: str = "http://{nomad_upstream_addr}",
+        unversioned_service_env_fmt: str = "NOMAD_UPSTREAM_ADDR_{service}",
+    ) -> None:
+        """ """
+        self.service_url_fmt = service_url_fmt
+        self.service_env_fmt = service_env_fmt
+        self.unversioned_service_url_fmt = unversioned_service_url_fmt
+        self.unversioned_service_env_fmt = unversioned_service_env_fmt
+
     async def get_endpoint(self, service: ServiceName, version: Version = None) -> Url:
         """
         Retrieve endpoint using the given parameters from `endpoints`.
         """
-        env_addr = os.getenv(f"NOMAD_UPSTREAM_ADDR_{service}")
-        if not env_addr:
+        env_fmt = self.service_env_fmt if version else self.unversioned_service_env_fmt
+        nomad_upstream_addr = os.getenv(
+            env_fmt.format(service=service, version=version)
+        )
+        if not nomad_upstream_addr:
             raise UnregisteredServiceException(service, version)
-        return f"http://{env_addr}"
+        url_fmt = self.service_url_fmt if version else self.unversioned_service_url_fmt
+        return url_fmt.format(nomad_upstream_addr=nomad_upstream_addr, version=version)

--- a/src/blacksmith/sd/_sync/adapters/consul.py
+++ b/src/blacksmith/sd/_sync/adapters/consul.py
@@ -73,17 +73,20 @@ class SyncConsulDiscovery(SyncAbstractServiceDiscovery):
     """
     A discovery instance based on a :term:`Consul` server.
 
-    :param service_name_fmt: pattern for name of versionned service
-    :param service_url_fmt: pattern for url of versionned service
-    :param unversioned_service_name_fmt: pattern for name of unversioned service
-    :param unversioned_service_url_fmt: pattern for url of unversioned service
-
+    :param addr: endpoint of the consul v1 http api.
+    :param service_name_fmt: pattern for name of versionned service.
+    :param service_url_fmt: pattern for url of versionned service.
+    :param unversioned_service_name_fmt: pattern for name of unversioned service.
+    :param unversioned_service_url_fmt: pattern for url of unversioned service.
+    :param consul_token: If set, the consul token is sent on http api call.
     """
 
+    addr: str
     service_name_fmt: str
     service_url_fmt: str
     unversioned_service_name_fmt: str
     unversioned_service_url_fmt: str
+    consul_token: str
 
     def __init__(
         self,

--- a/src/blacksmith/sd/_sync/adapters/nomad.py
+++ b/src/blacksmith/sd/_sync/adapters/nomad.py
@@ -17,11 +17,28 @@ class SyncNomadDiscovery(SyncAbstractServiceDiscovery):
     A discovery instance based on Nomad environment variables.
     """
 
+    def __init__(
+        self,
+        service_url_fmt: str = "http://{nomad_upstream_addr}/{version}",
+        service_env_fmt: str = "NOMAD_UPSTREAM_ADDR_{service}-{version}",
+        unversioned_service_url_fmt: str = "http://{nomad_upstream_addr}",
+        unversioned_service_env_fmt: str = "NOMAD_UPSTREAM_ADDR_{service}",
+    ) -> None:
+        """ """
+        self.service_url_fmt = service_url_fmt
+        self.service_env_fmt = service_env_fmt
+        self.unversioned_service_url_fmt = unversioned_service_url_fmt
+        self.unversioned_service_env_fmt = unversioned_service_env_fmt
+
     def get_endpoint(self, service: ServiceName, version: Version = None) -> Url:
         """
         Retrieve endpoint using the given parameters from `endpoints`.
         """
-        env_addr = os.getenv(f"NOMAD_UPSTREAM_ADDR_{service}")
-        if not env_addr:
+        env_fmt = self.service_env_fmt if version else self.unversioned_service_env_fmt
+        nomad_upstream_addr = os.getenv(
+            env_fmt.format(service=service, version=version)
+        )
+        if not nomad_upstream_addr:
             raise UnregisteredServiceException(service, version)
-        return f"http://{env_addr}"
+        url_fmt = self.service_url_fmt if version else self.unversioned_service_url_fmt
+        return url_fmt.format(nomad_upstream_addr=nomad_upstream_addr, version=version)

--- a/tests/functionals/conftest.py
+++ b/tests/functionals/conftest.py
@@ -1,6 +1,6 @@
+import time
 from enum import Enum
 from multiprocessing import Process
-import time
 from typing import Dict, Iterable, List, Optional, Type
 
 import pytest

--- a/tests/unittests/_async/test_sd.py
+++ b/tests/unittests/_async/test_sd.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from blacksmith.domain.exceptions import UnregisteredServiceException
@@ -132,13 +134,15 @@ async def test_consul_resolve_consul_error(consul_sd: AsyncConsulDiscovery):
     assert str(ctx.value) == "422 Unprocessable entity"
 
 
-async def test_nomad_resolve_dummy(nomad_sd: AsyncNomadDiscovery, monkeypatch):
-    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
+async def test_nomad_resolve_dummy(nomad_sd: AsyncNomadDiscovery, monkeypatch: Any):
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy-v1", "127.0.0.1:8000")
     endpoint: str = await nomad_sd.get_endpoint("dummy", "v1")
-    assert endpoint == "http://127.0.0.1:8000"
+    assert endpoint == "http://127.0.0.1:8000/v1"
 
 
-async def test_nomad_resolve_dummy_nover(nomad_sd: AsyncNomadDiscovery, monkeypatch):
+async def test_nomad_resolve_dummy_nover(
+    nomad_sd: AsyncNomadDiscovery, monkeypatch: Any
+):
     monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
     endpoint: str = await nomad_sd.get_endpoint("dummy")
     assert endpoint == "http://127.0.0.1:8000"

--- a/tests/unittests/_sync/test_sd.py
+++ b/tests/unittests/_sync/test_sd.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from blacksmith.domain.exceptions import UnregisteredServiceException
@@ -132,13 +134,13 @@ def test_consul_resolve_consul_error(consul_sd: SyncConsulDiscovery):
     assert str(ctx.value) == "422 Unprocessable entity"
 
 
-def test_nomad_resolve_dummy(nomad_sd: SyncNomadDiscovery, monkeypatch):
-    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
+def test_nomad_resolve_dummy(nomad_sd: SyncNomadDiscovery, monkeypatch: Any):
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy-v1", "127.0.0.1:8000")
     endpoint: str = nomad_sd.get_endpoint("dummy", "v1")
-    assert endpoint == "http://127.0.0.1:8000"
+    assert endpoint == "http://127.0.0.1:8000/v1"
 
 
-def test_nomad_resolve_dummy_nover(nomad_sd: SyncNomadDiscovery, monkeypatch):
+def test_nomad_resolve_dummy_nover(nomad_sd: SyncNomadDiscovery, monkeypatch: Any):
     monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
     endpoint: str = nomad_sd.get_endpoint("dummy")
     assert endpoint == "http://127.0.0.1:8000"


### PR DESCRIPTION
Properly implement nomad using a version


Important note.

There is a breaking change here that cam be fixed using configuration parameter like this.


```bash
AsyncNomadDiscovery(
        service_url_fmt: str = "http://{nomad_upstream_addr}",
        service_env_fmt: str = "NOMAD_UPSTREAM_ADDR_{service}",
        unversioned_service_url_fmt: str = "http://{nomad_upstream_addr}",
        unversioned_service_env_fmt: str = "NOMAD_UPSTREAM_ADDR_{service}",
)
```

but it is actually a bug and will be release as a minor version

