### PR TITLE
Enhanced Nomad + Consul Connect SD driver with external services considerations

### DIFF
--- a/docs/source/user/sd/service_discovery.rst
+++ b/docs/source/user/sd/service_discovery.rst
@@ -79,6 +79,13 @@ When using Consul Connect in a Nomad cluster, upstreams declared in a jobspec
 make available a mTLS connection on a `local_bind_port`. Addresses of these
 services are injected as environment variables during deployment of the job.
 
+For services behind a reverse proxy or with a strict TLS connection it's
+possible to force use of a different value than the Nomad generated one. Define
+`UPSTREAM_REAL_ADDR_<service>[_<version>]` and `UPSTREAM_REAL_SCHEME_<service>[_<version>]`
+environment variables to force these values to be used. Rewrite of /etc/hosts inside
+container permit to solve invalid certificate or virtual host for an endpoint
+routed thru mTLS connection on 127.0.0.1:<local_bind_port>.
+
 Async
 ~~~~~
 

--- a/src/blacksmith/sd/_async/adapters/nomad.py
+++ b/src/blacksmith/sd/_async/adapters/nomad.py
@@ -29,11 +29,27 @@ class AsyncNomadDiscovery(AsyncAbstractServiceDiscovery):
         self.service_env_fmt = service_env_fmt
         self.unversioned_service_url_fmt = unversioned_service_url_fmt
         self.unversioned_service_env_fmt = unversioned_service_env_fmt
+        # External services discovery
+        self.service_real_addr_fmt: str = "UPSTREAM_REAL_ADDR_{service}_{version}"
+        self.service_real_scheme_fmt: str = "UPSTREAM_REAL_SCHEME_{service}_{version}"
 
     async def get_endpoint(self, service: ServiceName, version: Version = None) -> Url:
         """
         Retrieve endpoint using the given parameters from `endpoints`.
         """
+        real_upstream_addr = os.getenv(
+            self.service_real_addr_fmt.format(service=service, version=version)
+        )
+        if real_upstream_addr:
+            lookup_scheme = self.service_real_scheme_fmt.format(
+                service=service, version=version
+            )
+            real_upstream_scheme = os.getenv(lookup_scheme, 'http')
+            return "{scheme}://{addr}/{version}".format(
+                scheme=real_upstream_scheme,
+                addr=real_upstream_addr,
+                version=version
+            )
         env_fmt = self.service_env_fmt if version else self.unversioned_service_env_fmt
         nomad_upstream_addr = os.getenv(
             env_fmt.format(service=service, version=version)

--- a/src/blacksmith/sd/_async/adapters/nomad.py
+++ b/src/blacksmith/sd/_async/adapters/nomad.py
@@ -30,26 +30,24 @@ class AsyncNomadDiscovery(AsyncAbstractServiceDiscovery):
         self.unversioned_service_url_fmt = unversioned_service_url_fmt
         self.unversioned_service_env_fmt = unversioned_service_env_fmt
         # External services discovery
-        self.service_real_addr_fmt: str = "UPSTREAM_REAL_ADDR_{service}_{version}"
-        self.service_real_scheme_fmt: str = "UPSTREAM_REAL_SCHEME_{service}_{version}"
+        self.service_real_addr_fmt: str = "UPSTREAM_REAL_ADDR_{service_key}"
+        self.service_real_scheme_fmt: str = "UPSTREAM_REAL_SCHEME_{service_key}"
 
     async def get_endpoint(self, service: ServiceName, version: Version = None) -> Url:
         """
         Retrieve endpoint using the given parameters from `endpoints`.
         """
+        lookup_key = f"{service}_{version}" if version else service
         real_upstream_addr = os.getenv(
-            self.service_real_addr_fmt.format(service=service, version=version)
+            self.service_real_addr_fmt.format(service_key=lookup_key)
         )
         if real_upstream_addr:
-            lookup_scheme = self.service_real_scheme_fmt.format(
-                service=service, version=version
-            )
-            real_upstream_scheme = os.getenv(lookup_scheme, 'http')
-            return "{scheme}://{addr}/{version}".format(
-                scheme=real_upstream_scheme,
-                addr=real_upstream_addr,
-                version=version
-            )
+            lookup_scheme = self.service_real_scheme_fmt.format(service_key=lookup_key)
+            real_upstream_scheme = os.getenv(lookup_scheme, "http")
+            end_url = f"/{version}" if version else ""
+            return f"{real_upstream_scheme}://{real_upstream_addr}{end_url}"
+
+        # Nomad normal environment variables mechanism
         env_fmt = self.service_env_fmt if version else self.unversioned_service_env_fmt
         nomad_upstream_addr = os.getenv(
             env_fmt.format(service=service, version=version)

--- a/src/blacksmith/sd/_sync/adapters/nomad.py
+++ b/src/blacksmith/sd/_sync/adapters/nomad.py
@@ -29,11 +29,25 @@ class SyncNomadDiscovery(SyncAbstractServiceDiscovery):
         self.service_env_fmt = service_env_fmt
         self.unversioned_service_url_fmt = unversioned_service_url_fmt
         self.unversioned_service_env_fmt = unversioned_service_env_fmt
+        # External services discovery
+        self.service_real_addr_fmt: str = "UPSTREAM_REAL_ADDR_{service_key}"
+        self.service_real_scheme_fmt: str = "UPSTREAM_REAL_SCHEME_{service_key}"
 
     def get_endpoint(self, service: ServiceName, version: Version = None) -> Url:
         """
         Retrieve endpoint using the given parameters from `endpoints`.
         """
+        lookup_key = f"{service}_{version}" if version else service
+        real_upstream_addr = os.getenv(
+            self.service_real_addr_fmt.format(service_key=lookup_key)
+        )
+        if real_upstream_addr:
+            lookup_scheme = self.service_real_scheme_fmt.format(service_key=lookup_key)
+            real_upstream_scheme = os.getenv(lookup_scheme, "http")
+            end_url = f"/{version}" if version else ""
+            return f"{real_upstream_scheme}://{real_upstream_addr}{end_url}"
+
+        # Nomad normal environment variables mechanism
         env_fmt = self.service_env_fmt if version else self.unversioned_service_env_fmt
         nomad_upstream_addr = os.getenv(
             env_fmt.format(service=service, version=version)

--- a/tests/unittests/_async/test_sd.py
+++ b/tests/unittests/_async/test_sd.py
@@ -148,6 +148,35 @@ async def test_nomad_resolve_dummy_nover(
     assert endpoint == "http://127.0.0.1:8000"
 
 
+async def test_nomad_resolve_real_upstream_dummy(
+    nomad_sd: AsyncNomadDiscovery, monkeypatch: Any
+):
+    monkeypatch.setenv("UPSTREAM_REAL_ADDR_dummy_v1", "example.com")
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy_v1", "127.0.0.1:8000")
+    endpoint: str = await nomad_sd.get_endpoint("dummy", "v1")
+    assert endpoint == "http://example.com/v1"
+
+
+async def test_nomad_resolve_real_upstream_with_scheme(
+    nomad_sd: AsyncNomadDiscovery, monkeypatch: Any
+):
+    monkeypatch.setenv("UPSTREAM_REAL_ADDR_dummy_v1", "example.com:4443")
+    monkeypatch.setenv("UPSTREAM_REAL_SCHEME_dummy_v1", "https")
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy_v1", "127.0.0.1:8000")
+    endpoint: str = await nomad_sd.get_endpoint("dummy", "v1")
+    assert endpoint == "https://example.com:4443/v1"
+
+
+async def test_nomad_resolve_real_upstream_with_scheme_nover(
+    nomad_sd: AsyncNomadDiscovery, monkeypatch: Any
+):
+    monkeypatch.setenv("UPSTREAM_REAL_ADDR_dummy", "example.com:4443")
+    monkeypatch.setenv("UPSTREAM_REAL_SCHEME_dummy", "https")
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
+    endpoint: str = await nomad_sd.get_endpoint("dummy")
+    assert endpoint == "https://example.com:4443"
+
+
 async def test_nomad_resolve_unregistered(nomad_sd: AsyncNomadDiscovery):
     with pytest.raises(UnregisteredServiceException) as ctx:
         await nomad_sd.get_endpoint("dummy", "v2")

--- a/tests/unittests/_sync/test_sd.py
+++ b/tests/unittests/_sync/test_sd.py
@@ -146,6 +146,35 @@ def test_nomad_resolve_dummy_nover(nomad_sd: SyncNomadDiscovery, monkeypatch: An
     assert endpoint == "http://127.0.0.1:8000"
 
 
+def test_nomad_resolve_real_upstream_dummy(
+    nomad_sd: SyncNomadDiscovery, monkeypatch: Any
+):
+    monkeypatch.setenv("UPSTREAM_REAL_ADDR_dummy_v1", "example.com")
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy_v1", "127.0.0.1:8000")
+    endpoint: str = nomad_sd.get_endpoint("dummy", "v1")
+    assert endpoint == "http://example.com/v1"
+
+
+def test_nomad_resolve_real_upstream_with_scheme(
+    nomad_sd: SyncNomadDiscovery, monkeypatch: Any
+):
+    monkeypatch.setenv("UPSTREAM_REAL_ADDR_dummy_v1", "example.com:4443")
+    monkeypatch.setenv("UPSTREAM_REAL_SCHEME_dummy_v1", "https")
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy_v1", "127.0.0.1:8000")
+    endpoint: str = nomad_sd.get_endpoint("dummy", "v1")
+    assert endpoint == "https://example.com:4443/v1"
+
+
+def test_nomad_resolve_real_upstream_with_scheme_nover(
+    nomad_sd: SyncNomadDiscovery, monkeypatch: Any
+):
+    monkeypatch.setenv("UPSTREAM_REAL_ADDR_dummy", "example.com:4443")
+    monkeypatch.setenv("UPSTREAM_REAL_SCHEME_dummy", "https")
+    monkeypatch.setenv("NOMAD_UPSTREAM_ADDR_dummy", "127.0.0.1:8000")
+    endpoint: str = nomad_sd.get_endpoint("dummy")
+    assert endpoint == "https://example.com:4443"
+
+
 def test_nomad_resolve_unregistered(nomad_sd: SyncNomadDiscovery):
     with pytest.raises(UnregisteredServiceException) as ctx:
         nomad_sd.get_endpoint("dummy", "v2")


### PR DESCRIPTION
For external services it could be needed to use real fqdn instead of 127.0.0.1, manage that with environment variables that preceed the mechanism for service discovery of Consul Connect used in a Nomad cluster.

Environment variable to declare in a container are :
- UPSTREAM_REAL_ADDR_{service}_{version}
- UPSTREAM_REAL_SCHEME_{service}_{version}

The upstream scheme could change between 2 external services, so the second variable